### PR TITLE
Bump docker image to use go 1.23.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:alpine
+FROM golang:1.23.8-alpine
 
 LABEL "maintainer"="dadav <dadav@protonmail.com>"
 LABEL "repository"="https://github.com/nbycomp/jsonnet-lint-action"


### PR DESCRIPTION
Corrected docker image to make sure it uses well known version of go and matches some of our security standards